### PR TITLE
Class constant visibility is now removed directly by spatie/7to5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "php-http/mock-client": "^1.0",
         "php-mock/php-mock-phpunit": "^1.0 || ^2.0",
         "phpunit/phpunit": "^5.7 || ^6.4 <6.5",
-        "spatie/7to5": "^1.2",
+        "spatie/7to5": "^1.3",
         "symfony/var-dumper": "^3.3"
     },
     "scripts": {

--- a/transpile.sh
+++ b/transpile.sh
@@ -11,11 +11,6 @@ git clone git@github.com:lmc-eu/matej-client-php.git tmp-7/
 vendor/bin/php7to5 convert tmp-7/src/ tmp-5/src
 vendor/bin/php7to5 convert tmp-7/tests/ tmp-5/tests
 
-for FN in $(find tmp-5/ -type f -name "*.php"); do
-    # Remove class constants visibility, see https://github.com/spatie/7to5/issues/30
-    sed -i -- "s/\(protected\|private\|public\) const/const/g" $FN
-done
-
 # Copy non-php fixtures from tests
 for FN in $(find tmp-7/tests/ -type f -not -name "*.php"); do
     RELATIVE_PATH=$(echo $FN | sed s~tmp-7/~~)


### PR DESCRIPTION
Class constant visibility removal is now [builtin](https://github.com/spatie/7to5/pull/37) to spatie/7to5.